### PR TITLE
INTELSDK-2483 Update package

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,4 +4,4 @@ This software is licensed under the [Omnissa Software Development Kit (SDK) Lice
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-This software may also utilize Third-Pary Open Source Software as detailed within the [open_source_licenses.txt](open_source_licenses.txt) file.
+This software may also utilize Third-Pary Open Source Software as detailed within the attached `open_source_licenses.txt.zip` file.

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 //  Package.swift
 //  WS1IntelligenceSDK
 //
-//  Copyright (c) 2025 Omnissa, LLC. All rights reserved.
+//  Copyright (c) 2023 Omnissa, LLC. All rights reserved.
 //  This product is protected by copyright and intellectual property laws in the
 //  United States and other countries as well as by international treaties.
 //  -- Omnissa Public
@@ -21,7 +21,7 @@ let package = Package(
             targets: ["WS1IntelligenceSDK"]),
     ],
     targets: [
-        .binaryTarget(name: "WS1IntelligenceSDK", url: "https://github.com/euc-releases/ws1-intelligencesdk-sdk-ios/releases/download/24.3.0/WS1IntelligenceSDK.xcframework.zip", checksum:"359ba1e8db1a9b9112c06382c15f0229c68657353277b390686c867bd550d3ed")
+        .binaryTarget(name: "WS1IntelligenceSDK", url: "https://github.com/euc-releases/ws1-intelligencesdk-sdk-ios/releases/download/24.8.0/WS1IntelligenceSDK.xcframework.zip", checksum:"62f38368e74c9511a28af3fed7e3985727da6c85fa2c0a6f086c25948844dc88")
     ]
 )
 


### PR DESCRIPTION
Package.swift
- update copyright to use the original publishing date (first released with SPM in 2023)
- point to the version 24.8.0 binaries
- update SHA-256 checksum

LICENSE.md
- updated to mention the OSL file as attached rather than as a link into the repository contents.
