### PR TITLE
INTELSDK-2646 Fix README reference to open_source_licenses.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ This software is licensed under the [Omnissa Software Development Kit (SDK) Lice
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-This software may also utilize Third-Pary Open Source Software as detailed within the [open_source_licenses.txt](open_source_licenses.txt) file.
+This software may also utilize Third-Pary Open Source Software as detailed within the attached `open_source_licenses.txt.zip` file.


### PR DESCRIPTION
Updated README file to have the same sentence about open_source_licenses file the LICENSE file contains.

"This software may also utilize Third-Pary Open Source Software as detailed within the attached open_source_licenses.txt.zip file."

The open_source_licenses file is no longer contained in the repository.  It is attached to each release alongside the attached binaries. 
